### PR TITLE
Slashnet fix

### DIFF
--- a/cinch-identify.gemspec
+++ b/cinch-identify.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'cinch-identify'
-  s.version = '1.7.0'
+  s.version = '1.7.0.1'
   s.summary = 'A plugin allowing Cinch bots to automatically identify with services.'
   s.description = 'A plugin allowing Cinch bots to automatically identify with services. Supported are NickServ, QuakeNet and KreyNet.'
   s.authors = ['Dominik Honnef']

--- a/lib/cinch/plugins/identify.rb
+++ b/lib/cinch/plugins/identify.rb
@@ -34,8 +34,8 @@ module Cinch
 
       match(/^You are successfully identified as/,           use_prefix: false, use_suffix: false, react_on: :private, method: :identified_nickserv)
       match(/^You are now identified for/,                   use_prefix: false, use_suffix: false, react_on: :private, method: :identified_nickserv)
-      match(/^Password accepted - you are now recognized\./, use_prefix: false, use_suffix: false, react_on: :private, method: :identified_nickserv)
-      match(/^Hasło przyjęte - jesteś zidentyfikowany/,      use_prefix: false, use_suffix: false, react_on: :private, method: :identified_nickserv)
+      match(/^Password accepted -+ you are now recognized\./, use_prefix: false, use_suffix: false, react_on: :private, method: :identified_nickserv)
+      match(/^Hasło przyjęte -+ jesteś zidentyfikowany/,      use_prefix: false, use_suffix: false, react_on: :private, method: :identified_nickserv)
       def identified_nickserv(m)
         service_name = config[:service_name] || "nickserv"
         if m.user == User(service_name) && config[:type] == :nickserv


### PR DESCRIPTION
This PR fixes firing of the `:identified` event on SlashNet with Nickserv. SlashNet uses a double dash in the message for successful identification, regex matchers will now match on one or more dashes.